### PR TITLE
theme bibw 0.5

### DIFF
--- a/static/img/icons/coffreouvert.svg
+++ b/static/img/icons/coffreouvert.svg
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 50 50" style="enable-background:new 0 0 50 50;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#222222;}
+	.st1{fill:none;stroke:#FFFFFF;stroke-width:0.5;stroke-miterlimit:10;}
+	.st2{fill:#494949;}
+	.st3{fill:#DB1233;}
+	.st4{fill:#FFFFFF;}
+	.st5{fill:#F6F5F5;}
+	.st6{fill:#231F20;}
+	.st7{fill:#2B3C41;}
+	.st8{clip-path:url(#SVGID_4_);}
+	.st9{clip-path:url(#SVGID_6_);}
+	.st10{fill:#4B58A3;}
+	.st11{fill:#D2A639;}
+	.st12{fill:#1F968B;}
+	.st13{fill:#6DB64C;}
+	.st14{fill:#B5204D;}
+	.st15{fill:#CCD7ED;}
+	.st16{clip-path:url(#SVGID_8_);}
+	.st17{fill:#EC365C;}
+	.st18{fill:#939598;}
+	.st19{fill:#7E8283;}
+	.st20{fill:#3C5AA5;}
+	.st21{fill:#213364;}
+	.st22{fill:url(#SVGID_9_);}
+	.st23{fill:url(#SVGID_10_);}
+	.st24{fill:url(#SVGID_11_);}
+	.st25{fill:url(#l1_7_);}
+	.st26{fill:url(#SVGID_12_);}
+	.st27{fill:url(#SVGID_13_);}
+	.st28{fill:url(#SVGID_14_);}
+	.st29{fill:url(#SVGID_15_);}
+	.st30{fill:url(#SVGID_16_);}
+	.st31{fill:#3A62AC;}
+	.st32{fill:url(#SVGID_17_);}
+	.st33{fill:url(#SVGID_18_);}
+	.st34{fill-opacity:0;stroke:#FFFFFF;stroke-width:3;}
+	.st35{fill:#FFCC05;}
+	.st36{fill:#B28E03;}
+	.st37{fill:url(#SVGID_19_);}
+	.st38{fill:url(#SVGID_20_);}
+	.st39{fill:url(#SVGID_21_);}
+	.st40{fill:url(#l1_8_);}
+	.st41{fill:url(#SVGID_22_);}
+	.st42{fill:url(#SVGID_23_);}
+	.st43{fill:url(#SVGID_24_);}
+	.st44{fill:url(#SVGID_25_);}
+	.st45{fill:url(#SVGID_26_);}
+	.st46{fill:url(#SVGID_27_);}
+	.st47{fill:url(#SVGID_28_);}
+	.st48{fill:#1A335A;}
+	.st49{fill:#332314;}
+	.st50{fill:#E9BE11;}
+	.st51{fill:#B93824;}
+	.st52{fill:#E6E0DA;}
+	.st53{fill:#B73828;}
+	.st54{fill:#EBBE0E;}
+	.st55{fill:#9E549E;}
+	.st56{fill:#D6D6D6;}
+	.st57{fill:#27AAFE;stroke:#231F20;stroke-width:2;stroke-miterlimit:10;}
+	.st58{fill:#F7C028;}
+	.st59{fill:#F71235;}
+	.st60{fill:#FFE63E;}
+	.st61{fill:#61B16C;}
+	.st62{fill:none;stroke:#231F20;stroke-width:3;stroke-miterlimit:10;}
+	.st63{fill:none;stroke:#231F20;stroke-width:2;stroke-linecap:round;stroke-miterlimit:10;}
+	.st64{fill:#F9F9F9;}
+	.st65{fill:#F2CD16;}
+	.st66{fill:#FE120C;}
+	.st67{fill:none;stroke:#231F20;stroke-width:3.66;stroke-miterlimit:10;}
+	.st68{fill:none;stroke:#231F20;stroke-width:3;stroke-linecap:round;stroke-miterlimit:10;}
+	.st69{fill:#D1D0C8;stroke:#231F20;stroke-width:3.6666;stroke-miterlimit:10;}
+	.st70{fill:#231F20;stroke:#231F20;stroke-width:3.6666;stroke-miterlimit:10;}
+	.st71{fill:#FE120C;stroke:#231F20;stroke-width:3.6666;stroke-miterlimit:10;}
+	.st72{fill:none;}
+	.st73{fill:#E7F414;stroke:#231F20;stroke-width:2;stroke-linecap:round;stroke-miterlimit:10;}
+	.st74{fill:#F2CD16;stroke:#231F20;stroke-width:2;stroke-linecap:round;stroke-miterlimit:10;}
+	.st75{fill:none;stroke:#FE120C;stroke-width:2;stroke-linecap:round;stroke-miterlimit:10;}
+	.st76{fill:#FFFFFF;stroke:#231F20;stroke-width:2;stroke-miterlimit:10;}
+	.st77{fill:#FE120C;stroke:#231F20;stroke-width:2;stroke-miterlimit:10;}
+	.st78{fill:#130C0A;}
+	.st79{fill:#F2CD16;stroke:#231F20;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+	.st80{fill:none;stroke:#FE120C;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+	.st81{fill:#27AAFE;}
+	.st82{fill:#D1D0C8;stroke:#231F20;stroke-width:3;stroke-miterlimit:10;}
+	.st83{fill:#FE120C;stroke:#231F20;stroke-width:3;stroke-miterlimit:10;}
+	.st84{fill:#D1D0C8;}
+	.st85{fill:#5D439C;}
+	.st86{fill:none;stroke:#FFFFFF;stroke-miterlimit:10;}
+	.st87{fill:#ED018C;}
+	.st88{fill:none;stroke:#1A1818;stroke-width:3;stroke-miterlimit:10;}
+	.st89{fill:#D1D0C8;stroke:#1A1818;stroke-width:3;stroke-miterlimit:10;}
+	.st90{fill:#0C0C0C;}
+	.st91{fill:#E8E8E8;}
+	.st92{fill:url(#SVGID_35_);}
+	.st93{fill:url(#SVGID_40_);}
+	.st94{fill:url(#SVGID_41_);}
+	.st95{fill:url(#SVGID_42_);}
+	.st96{fill:url(#l1_9_);}
+	.st97{fill:url(#SVGID_43_);}
+	.st98{fill:url(#SVGID_44_);}
+	.st99{fill:url(#SVGID_45_);}
+	.st100{fill:url(#SVGID_46_);}
+	.st101{fill:url(#SVGID_47_);}
+	.st102{fill:url(#SVGID_48_);}
+	.st103{fill:url(#SVGID_49_);}
+	.st104{fill:url(#SVGID_50_);}
+	.st105{fill:url(#SVGID_51_);}
+	.st106{fill:url(#SVGID_52_);}
+	.st107{fill:url(#l1_10_);}
+	.st108{fill:url(#SVGID_53_);}
+	.st109{fill:url(#SVGID_54_);}
+	.st110{fill:url(#SVGID_55_);}
+	.st111{fill:url(#SVGID_56_);}
+	.st112{fill:url(#SVGID_57_);}
+	.st113{fill:url(#SVGID_58_);}
+	.st114{fill:url(#SVGID_59_);}
+	.st115{fill:none;stroke:#3A3A3A;stroke-miterlimit:10;}
+	.st116{fill:#E2E0E3;}
+	.st117{fill:#0D0299;}
+	.st118{fill:url(#SVGID_60_);}
+	.st119{fill:url(#SVGID_61_);}
+	.st120{fill:url(#SVGID_62_);}
+	.st121{fill:url(#SVGID_63_);}
+	.st122{fill:url(#l1_11_);}
+	.st123{fill:url(#SVGID_64_);}
+	.st124{fill:url(#SVGID_65_);}
+	.st125{fill:url(#SVGID_66_);}
+	.st126{fill:url(#SVGID_67_);}
+	.st127{fill:url(#SVGID_68_);}
+	.st128{fill:url(#SVGID_69_);}
+	.st129{fill:url(#SVGID_70_);}
+	.st130{fill:url(#SVGID_71_);}
+	.st131{fill:url(#SVGID_72_);}
+	.st132{fill:url(#SVGID_73_);}
+	.st133{fill:url(#l1_12_);}
+	.st134{fill:url(#SVGID_74_);}
+	.st135{fill:url(#SVGID_75_);}
+	.st136{fill:url(#SVGID_76_);}
+	.st137{fill:url(#SVGID_77_);}
+	.st138{fill:url(#SVGID_78_);}
+	.st139{fill:url(#SVGID_79_);}
+	.st140{fill:url(#SVGID_80_);}
+	.st141{fill:url(#SVGID_81_);}
+	.st142{fill:#FF3E60;}
+	.st143{fill:#010101;}
+</style>
+<g id="Calque_1">
+</g>
+<g id="Calque_2">
+	<path class="st6" d="M48.3,25C48.3,25,48.3,24.9,48.3,25C48.3,25,48.3,25,48.3,25C48.3,25,48.3,25,48.3,25z"/>
+	<g>
+		<rect y="0" class="st48" width="50" height="50"/>
+		<rect y="46.9" width="50" height="3.1"/>
+		<rect y="3.1" class="st65" width="50" height="43.8"/>
+		<rect x="23.5" y="23.5" transform="matrix(-1.347511e-10 1 -1 -1.347511e-10 73.4586 -23.4586)" width="50" height="3.1"/>
+		<rect x="6.3" y="6.3" class="st51" width="34.5" height="12.5"/>
+		<rect x="12.4" y="3.1" class="st52" width="3.2" height="3.2"/>
+		<rect y="34.4" width="50" height="3.1"/>
+		<rect y="0" width="50" height="3.1"/>
+		<rect x="-23.5" y="23.5" transform="matrix(-1.346782e-10 1 -1 -1.346782e-10 26.5414 23.4586)" width="50" height="3.1"/>
+		<rect x="29.8" y="17.2" transform="matrix(-2.703058e-10 1 -1 -2.703058e-10 61.042 -23.5407)" width="25" height="3.1"/>
+		<rect x="-4.6" y="17.2" transform="matrix(-2.703058e-10 1 -1 -2.703058e-10 26.6559 10.8454)" width="25" height="3.1"/>
+		<rect x="9.4" y="-3.2" transform="matrix(-2.627013e-09 1 -1 -2.627013e-09 40.6675 -9.4305)" width="31.2" height="37.6"/>
+		<rect x="6.3" y="37.5" width="3.2" height="3.2"/>
+		<rect x="9.3" y="37.5" class="st53" width="6.2" height="3.2"/>
+		<rect x="34.2" y="37.5" class="st53" width="6.2" height="3.2"/>
+		<rect x="18.7" y="34.4" class="st65" width="3.2" height="3.2"/>
+		<rect x="28" y="34.4" class="st65" width="3.2" height="3.2"/>
+		<rect x="15.5" y="37.5" width="3.2" height="3.2"/>
+		<rect x="31.2" y="37.5" width="3.2" height="3.2"/>
+		<rect x="40.4" y="37.5" width="3.2" height="3.2"/>
+		<rect x="6.3" y="3.1" class="st116" width="37.6" height="3.2"/>
+		<rect x="9.4" y="18.8" class="st117" width="31.4" height="12.5"/>
+		<rect x="6.3" y="40.7" width="37.3" height="3.1"/>
+		<rect x="3.1" y="31.2" class="st116" width="43.8" height="3.2"/>
+		<rect x="3.1" y="3.1" class="st116" width="3.2" height="28.2"/>
+		<rect x="43.6" y="3.1" class="st116" width="3.2" height="28.2"/>
+	</g>
+</g>
+<g id="Calque_3">
+</g>
+</svg>

--- a/static/img/icons/masterball.svg
+++ b/static/img/icons/masterball.svg
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 50 50" style="enable-background:new 0 0 50 50;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#222222;}
+	.st1{fill:none;stroke:#FFFFFF;stroke-width:0.5;stroke-miterlimit:10;}
+	.st2{fill:#494949;}
+	.st3{fill:#DB1233;}
+	.st4{fill:#FFFFFF;}
+	.st5{fill:#F6F5F5;}
+	.st6{fill:#231F20;}
+	.st7{fill:#2B3C41;}
+	.st8{clip-path:url(#SVGID_4_);}
+	.st9{clip-path:url(#SVGID_6_);}
+	.st10{fill:#4B58A3;}
+	.st11{fill:#D2A639;}
+	.st12{fill:#1F968B;}
+	.st13{fill:#6DB64C;}
+	.st14{fill:#B5204D;}
+	.st15{fill:#CCD7ED;}
+	.st16{clip-path:url(#SVGID_8_);}
+	.st17{fill:#EC365C;}
+	.st18{fill:#939598;}
+	.st19{fill:#7E8283;}
+	.st20{fill:#3C5AA5;}
+	.st21{fill:#213364;}
+	.st22{fill:url(#SVGID_9_);}
+	.st23{fill:url(#SVGID_10_);}
+	.st24{fill:url(#SVGID_11_);}
+	.st25{fill:url(#l1_7_);}
+	.st26{fill:url(#SVGID_12_);}
+	.st27{fill:url(#SVGID_13_);}
+	.st28{fill:url(#SVGID_14_);}
+	.st29{fill:url(#SVGID_15_);}
+	.st30{fill:url(#SVGID_16_);}
+	.st31{fill:#3A62AC;}
+	.st32{fill:url(#SVGID_17_);}
+	.st33{fill:url(#SVGID_18_);}
+	.st34{fill-opacity:0;stroke:#FFFFFF;stroke-width:3;}
+	.st35{fill:#FFCC05;}
+	.st36{fill:#B28E03;}
+	.st37{fill:url(#SVGID_19_);}
+	.st38{fill:url(#SVGID_20_);}
+	.st39{fill:url(#SVGID_21_);}
+	.st40{fill:url(#l1_8_);}
+	.st41{fill:url(#SVGID_22_);}
+	.st42{fill:url(#SVGID_23_);}
+	.st43{fill:url(#SVGID_24_);}
+	.st44{fill:url(#SVGID_25_);}
+	.st45{fill:url(#SVGID_26_);}
+	.st46{fill:url(#SVGID_27_);}
+	.st47{fill:url(#SVGID_28_);}
+	.st48{fill:#1A335A;}
+	.st49{fill:#332314;}
+	.st50{fill:#E9BE11;}
+	.st51{fill:#B93824;}
+	.st52{fill:#E6E0DA;}
+	.st53{fill:#B73828;}
+	.st54{fill:#EBBE0E;}
+	.st55{fill:#9E549E;}
+	.st56{fill:#D6D6D6;}
+	.st57{fill:#27AAFE;stroke:#231F20;stroke-width:2;stroke-miterlimit:10;}
+	.st58{fill:#F7C028;}
+	.st59{fill:#F71235;}
+	.st60{fill:#FFE63E;}
+	.st61{fill:#61B16C;}
+	.st62{fill:none;stroke:#231F20;stroke-width:3;stroke-miterlimit:10;}
+	.st63{fill:none;stroke:#231F20;stroke-width:2;stroke-linecap:round;stroke-miterlimit:10;}
+	.st64{fill:#F9F9F9;}
+	.st65{fill:#F2CD16;}
+	.st66{fill:#FE120C;}
+	.st67{fill:none;stroke:#231F20;stroke-width:3.66;stroke-miterlimit:10;}
+	.st68{fill:none;stroke:#231F20;stroke-width:3;stroke-linecap:round;stroke-miterlimit:10;}
+	.st69{fill:#D1D0C8;stroke:#231F20;stroke-width:3.6666;stroke-miterlimit:10;}
+	.st70{fill:#231F20;stroke:#231F20;stroke-width:3.6666;stroke-miterlimit:10;}
+	.st71{fill:#FE120C;stroke:#231F20;stroke-width:3.6666;stroke-miterlimit:10;}
+	.st72{fill:none;}
+	.st73{fill:#E7F414;stroke:#231F20;stroke-width:2;stroke-linecap:round;stroke-miterlimit:10;}
+	.st74{fill:#F2CD16;stroke:#231F20;stroke-width:2;stroke-linecap:round;stroke-miterlimit:10;}
+	.st75{fill:none;stroke:#FE120C;stroke-width:2;stroke-linecap:round;stroke-miterlimit:10;}
+	.st76{fill:#FFFFFF;stroke:#231F20;stroke-width:2;stroke-miterlimit:10;}
+	.st77{fill:#FE120C;stroke:#231F20;stroke-width:2;stroke-miterlimit:10;}
+	.st78{fill:#130C0A;}
+	.st79{fill:#F2CD16;stroke:#231F20;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+	.st80{fill:none;stroke:#FE120C;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+	.st81{fill:#27AAFE;}
+	.st82{fill:#D1D0C8;stroke:#231F20;stroke-width:3;stroke-miterlimit:10;}
+	.st83{fill:#FE120C;stroke:#231F20;stroke-width:3;stroke-miterlimit:10;}
+	.st84{fill:#D1D0C8;}
+	.st85{fill:#5D439C;}
+	.st86{fill:none;stroke:#FFFFFF;stroke-miterlimit:10;}
+	.st87{fill:#ED018C;}
+	.st88{fill:none;stroke:#1A1818;stroke-width:3;stroke-miterlimit:10;}
+	.st89{fill:#D1D0C8;stroke:#1A1818;stroke-width:3;stroke-miterlimit:10;}
+	.st90{fill:#0C0C0C;}
+	.st91{fill:#E8E8E8;}
+	.st92{fill:url(#SVGID_35_);}
+	.st93{fill:url(#SVGID_40_);}
+	.st94{fill:url(#SVGID_41_);}
+	.st95{fill:url(#SVGID_42_);}
+	.st96{fill:url(#l1_9_);}
+	.st97{fill:url(#SVGID_43_);}
+	.st98{fill:url(#SVGID_44_);}
+	.st99{fill:url(#SVGID_45_);}
+	.st100{fill:url(#SVGID_46_);}
+	.st101{fill:url(#SVGID_47_);}
+	.st102{fill:url(#SVGID_48_);}
+	.st103{fill:url(#SVGID_49_);}
+	.st104{fill:url(#SVGID_50_);}
+	.st105{fill:url(#SVGID_51_);}
+	.st106{fill:url(#SVGID_52_);}
+	.st107{fill:url(#l1_10_);}
+	.st108{fill:url(#SVGID_53_);}
+	.st109{fill:url(#SVGID_54_);}
+	.st110{fill:url(#SVGID_55_);}
+	.st111{fill:url(#SVGID_56_);}
+	.st112{fill:url(#SVGID_57_);}
+	.st113{fill:url(#SVGID_58_);}
+	.st114{fill:url(#SVGID_59_);}
+	.st115{fill:none;stroke:#3A3A3A;stroke-miterlimit:10;}
+	.st116{fill:#1A1818;}
+	.st117{fill:#E2E0E3;}
+	.st118{fill:#0D0299;}
+	.st119{fill:url(#SVGID_60_);}
+	.st120{fill:url(#SVGID_61_);}
+	.st121{fill:url(#SVGID_62_);}
+	.st122{fill:url(#SVGID_63_);}
+	.st123{fill:url(#l1_11_);}
+	.st124{fill:url(#SVGID_64_);}
+	.st125{fill:url(#SVGID_65_);}
+	.st126{fill:url(#SVGID_66_);}
+	.st127{fill:url(#SVGID_67_);}
+	.st128{fill:url(#SVGID_68_);}
+	.st129{fill:url(#SVGID_69_);}
+	.st130{fill:url(#SVGID_70_);}
+	.st131{fill:url(#SVGID_71_);}
+	.st132{fill:url(#SVGID_72_);}
+	.st133{fill:url(#SVGID_73_);}
+	.st134{fill:url(#l1_12_);}
+	.st135{fill:url(#SVGID_74_);}
+	.st136{fill:url(#SVGID_75_);}
+	.st137{fill:url(#SVGID_76_);}
+	.st138{fill:url(#SVGID_77_);}
+	.st139{fill:url(#SVGID_78_);}
+	.st140{fill:url(#SVGID_79_);}
+	.st141{fill:url(#SVGID_80_);}
+	.st142{fill:url(#SVGID_81_);}
+	.st143{fill:#FF3E60;}
+	.st144{fill:#010101;}
+</style>
+<g id="Calque_1">
+</g>
+<g id="Calque_2">
+	<g>
+		<g>
+			<g>
+				<path class="st84" d="M24.9,31.6c-12.8,0-23.1-2.9-23.2-6.6V25c0,12.8,10.4,23.2,23.2,23.2S48.2,37.9,48.2,25v-0.1
+					C48.1,28.5,37.8,31.6,24.9,31.6z"/>
+				<g>
+					<polygon class="st6" points="3.5,24.9 -0.1,24.9 3.5,24.8 					"/>
+				</g>
+				<g>
+					<circle class="st84" cx="24.8" cy="29.1" r="7.5"/>
+					<path class="st6" d="M24.8,38.2c-5,0-9-4-9-9s4-9,9-9s9,4,9,9S29.8,38.2,24.8,38.2z M24.8,23.1c-3.3,0-6,2.7-6,6s2.7,6,6,6
+						s6-2.7,6-6S28.2,23.1,24.8,23.1z"/>
+				</g>
+				<path class="st85" d="M48.2,24.8c-0.1-12.7-10.5-23-23.2-23S1.8,12.1,1.7,24.8v0.1c0.1,3.6,10.4,6.6,23.2,6.6s23.1-2.9,23.2-6.6
+					C48.2,24.8,48.2,24.8,48.2,24.8z"/>
+			</g>
+		</g>
+		<polygon class="st4" points="20.7,17.2 19.3,16.7 22.1,8.8 24.7,13.6 27.7,8.9 30.4,16.5 29,17 27.3,12.3 24.6,16.6 22.4,12.4 		
+			"/>
+		<g>
+			<path class="st87" d="M17.6,12.4c0-3.1-2-5.7-5-7c-4.8,3-8.4,7.7-10,13.3c1.6,1.1,3.6,1.7,5.8,1.7C13.4,20.3,17.6,16.8,17.6,12.4
+				z"/>
+			<path class="st87" d="M37.2,5.4c-3,1.3-5,4-5,7c0,4.4,4.2,7.9,9.3,7.9c2.2,0,4.2-0.6,5.8-1.7C45.6,13.1,41.9,8.4,37.2,5.4z"/>
+		</g>
+		<g>
+			<g>
+				<path class="st116" d="M24.9,50.1C11.1,50.1-0.1,38.9-0.1,25h0c0,0,0,0,0-0.1l3.7-0.1c0,1.4,7.4,4.8,21.4,4.8
+					c13.8,0,21.4-3.4,21.4-4.8l3.7,0.1C50,38.9,38.8,50.1,24.9,50.1z M4.1,30c2.3,9.5,10.7,16.5,20.8,16.5
+					c10.1,0,18.6-7.1,20.8-16.6c-4.8,2.4-13,3.5-20.8,3.5C18.7,33.4,9.5,32.6,4.1,30z"/>
+				<g>
+					<polygon class="st6" points="3.5,24.9 -0.1,24.9 3.5,24.8 					"/>
+				</g>
+				<path class="st116" d="M24.9,33.4C13,33.4,0,30.8-0.1,25l0-0.2C0,11.1,11.2,0,24.9,0c13.7,0,25,11.1,25.1,24.9l0,0.1
+					C49.8,31.6,34.2,33.4,24.9,33.4z M24.9,3.6c-11.7,0-21.3,9.5-21.4,21.2l0,0.1c0,1.3,7.6,4.8,21.4,4.8c14,0,21.4-3.4,21.4-4.8v0
+					C46.3,13.2,36.7,3.6,24.9,3.6z"/>
+				<g>
+					<circle class="st84" cx="24.8" cy="29.1" r="7.5"/>
+					<path class="st116" d="M24.8,38.5c-5.2,0-9.3-4.2-9.3-9.3s4.2-9.3,9.3-9.3s9.3,4.2,9.3,9.3S30,38.5,24.8,38.5z M24.8,23.5
+						c-3.1,0-5.7,2.5-5.7,5.7s2.5,5.7,5.7,5.7s5.7-2.5,5.7-5.7S28,23.5,24.8,23.5z"/>
+				</g>
+			</g>
+		</g>
+	</g>
+</g>
+<g id="Calque_3">
+</g>
+</svg>

--- a/static/img/icons/pokedex.svg
+++ b/static/img/icons/pokedex.svg
@@ -4,89 +4,15 @@
 	 viewBox="0 0 50 50" style="enable-background:new 0 0 50 50;" xml:space="preserve">
 <style type="text/css">
 	.cst0{fill:#F2CD16;}
-	.cst1{fill:#E7F414;stroke:#231F20;stroke-width:2;stroke-linecap:round;stroke-miterlimit:10;}
-	.cst2{fill:none;stroke:#FE120C;stroke-width:2;stroke-linecap:round;stroke-miterlimit:10;}
 	.cst3{fill:#DB1233;}
-	.cst4{fill:#FFFFFF;}
-	.cst5{fill:#F6F5F5;}
 	.cst6{fill:#231F20;}
 	.cst7{fill:#2B3C41;}
 	.cst8{clip-path:url(#SVGID_2_);}
 	.cst9{clip-path:url(#SVGID_4_);}
 	.cst10{fill:#4B58A3;}
-	.cst11{fill:#D2A639;}
-	.cst12{fill:#1F968B;}
-	.cst13{fill:#6DB64C;}
-	.cst14{fill:#B5204D;}
-	.cst15{fill:#CCD7ED;}
-	.cst16{clip-path:url(#SVGID_6_);}
-	.cst17{fill:#EC365C;}
-	.cst18{fill:#939598;}
-	.cst19{fill:#7E8283;}
-	.cst20{clip-path:url(#SVGID_8_);}
-	.cst21{clip-path:url(#SVGID_10_);}
-	.cst22{clip-path:url(#SVGID_12_);}
-	.cst23{fill:#3C5AA5;}
-	.cst24{fill:#213364;}
-	.cst25{fill:url(#SVGID_13_);}
-	.cst26{fill:url(#SVGID_14_);}
-	.cst27{fill:url(#SVGID_15_);}
-	.cst28{fill:url(#l1_1_);}
-	.cst29{fill:url(#SVGID_16_);}
-	.cst30{fill:url(#SVGID_17_);}
-	.cst31{fill:url(#SVGID_18_);}
-	.cst32{fill:url(#SVGID_19_);}
-	.cst33{fill:url(#SVGID_20_);}
-	.cst34{fill:#3A62AC;}
-	.cst35{fill:url(#SVGID_21_);}
-	.cst36{fill:url(#SVGID_22_);}
-	.cst37{fill-opacity:0;stroke:#FFFFFF;stroke-width:3;}
-	.cst38{fill:#FFCC05;}
-	.cst39{fill:#B28E03;}
-	.cst40{fill:url(#SVGID_23_);}
-	.cst41{fill:url(#SVGID_24_);}
-	.cst42{fill:url(#SVGID_25_);}
-	.cst43{fill:url(#l1_4_);}
-	.cst44{fill:url(#SVGID_26_);}
-	.cst45{fill:url(#SVGID_27_);}
-	.cst46{fill:url(#SVGID_28_);}
-	.cst47{fill:url(#SVGID_29_);}
-	.cst48{fill:url(#SVGID_30_);}
-	.cst49{fill:url(#SVGID_31_);}
-	.cst50{fill:url(#SVGID_32_);}
-	.cst51{fill:#1A335A;}
-	.cst52{fill:#332314;}
-	.cst53{fill:#E9BE11;}
-	.cst54{fill:#B93824;}
-	.cst55{fill:#E6E0DA;}
-	.cst56{fill:#B73828;}
-	.cst57{fill:#EBBE0E;}
-	.cst58{fill:#9E549E;}
-	.cst59{fill:#D6D6D6;}
-	.cst60{fill:#27AAFE;stroke:#231F20;stroke-width:2;stroke-miterlimit:10;}
-	.cst61{fill:#F7C028;}
-	.cst62{fill:#F71235;}
-	.cst63{fill:#FFE63E;}
 	.cst64{fill:#61B16C;}
-	.cst65{fill:none;stroke:#231F20;stroke-width:3;stroke-miterlimit:10;}
-	.cst66{fill:none;stroke:#231F20;stroke-width:2;stroke-linecap:round;stroke-miterlimit:10;}
-	.cst67{fill:#F9F9F9;}
-	.cst68{fill:#FE120C;}
-	.cst69{fill:none;stroke:#231F20;stroke-width:3.66;stroke-miterlimit:10;}
-	.cst70{fill:none;stroke:#231F20;stroke-width:3;stroke-linecap:round;stroke-miterlimit:10;}
-	.cst71{fill:#D1D0C8;stroke:#231F20;stroke-width:3.6666;stroke-miterlimit:10;}
-	.cst72{fill:#231F20;stroke:#231F20;stroke-width:3.6666;stroke-miterlimit:10;}
-	.cst73{fill:#FE120C;stroke:#231F20;stroke-width:3.6666;stroke-miterlimit:10;}
-	.cst74{fill:none;}
-	.cst75{fill:#FFFFFF;stroke:#231F20;stroke-width:2;stroke-miterlimit:10;}
-	.cst76{fill:#FE120C;stroke:#231F20;stroke-width:2;stroke-miterlimit:10;}
-	.cst77{fill:#E7F414;}
-	.cst78{fill:#130C0A;}
-	.cst79{fill:#F2CD16;stroke:#231F20;stroke-width:2;stroke-linecap:round;stroke-miterlimit:10;}
 	.cst80{fill:#27AAFE;}
 </style>
-<g id="Calque_1">
-</g>
 <g id="Calque_2">
 	<path class="cst3" d="M45.2,50H4.8C2.2,50,0,47.9,0,45.2V4.9C0,2.2,2.2,0,4.8,0h40.3C47.8,0,50,2.2,50,4.9v40.3
 		C50,47.9,47.8,50,45.2,50z"/>

--- a/static/index.html
+++ b/static/index.html
@@ -23,9 +23,10 @@
 		</main>
 		<footer id="foot">
 			<input autofocus placeholder="Message..." id="input" maxlength="300">
+			<i class="curseur"></i>
 			<div>
 				<div class="icon">
-					<img src="img/icons/coffrenb.svg" alt="" id="mic"/>	
+					<img src="img/icons/coffre.svg" alt="" id="chest"/>	
 					<span class="tooltiptext">inventaire</span>
 				</div>
 				<div class="icon"/> 
@@ -37,7 +38,7 @@
 					<span class="tooltiptext">menu / wiki</span>
 				</div>
 				<div class="icon">
-					<img src="img/icons/pokeball.svg" alt="" id="userswitch"/>	
+					<img src="img/icons/masterball.svg" alt="" id="userswitch"/>	
 					<span class="tooltiptext">liste</span>
 				</div->
 			</div>
@@ -54,7 +55,7 @@
 						<span>Langue :</span><select id="lang"><option value="fr">Français</option><option value="en">English</option><option value="es">Español</option><option value="de">Deutsch</option></select>
 					</div>
 					<div class="option">
-						<span>Thème :</span><select id="theme"><option value="cozy">Toumiwmiw</option><option value="compact">Old Skool</option><option value="console">Minitel</option><option value="fat">Phat Katz</option></select>
+						<span>Thème :</span><select id="theme"><option value="bibw">Bibw (v0.5)</option><option value="cozy">Toumiwmiw</option><option value="compact">Old Skool</option><option value="console">Minitel</option><option value="fat">Phat Katz</option></select>
 					</div>
 					<div class="option">
 						<span>Couleur :</span><select id="color"><option value="night">Nwuiw</option><option value="day">Jouw</option><option value="retro">Zenennw</option><option value="retro_night">Nwoiw</option><option value="blue">Emixam</option></select>

--- a/static/script.js
+++ b/static/script.js
@@ -80,6 +80,7 @@ document.addEventListener('DOMContentLoaded', function() {
 				var i = document.createElement('i');
 				i.className = 'material-icons';
 				i.appendChild(document.createTextNode('info_outline'));
+				i.innerHTML = '<img class="pokeball" src="img/icons/pokeball.svg"/>';
 				row.appendChild(i);
 			}
 			else {
@@ -178,6 +179,7 @@ document.addEventListener('DOMContentLoaded', function() {
 		you = userid;
 	}
 	// Attack button
+	/*
 	var i2 = document.createElement('i');
 	i2.className = 'material-icons';
 	i2.appendChild(document.createTextNode('sports_mma' ));
@@ -185,7 +187,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
 	i2.onmousedown = function() {
 		ws.send(JSON.stringify({ type : 'attack', target : params.name, order : orderId}));
-	};
+	};*/
+
+
+
 
 	var phead = document.createElement('div'),
 		pbody = document.createElement('div'),
@@ -485,6 +490,19 @@ document.addEventListener('DOMContentLoaded', function() {
 		};
 	}
 
+	// Inventory chest
+	var chest = document.getElementById('chest');
+	
+	chest.onmouseover = function() {
+		chest.src = 'img/icons/coffreouvert.svg';
+	}
+	chest.onmouseout = function() {
+		chest.src = 'img/icons/coffre.svg';
+	}
+
+
+
+
 	// Users list display
 
 	var userswitch = document.getElementById('userswitch');
@@ -500,7 +518,7 @@ document.addEventListener('DOMContentLoaded', function() {
 	// WebSocket-related functions
 
 	var wsConnect = function() {
-		 ws = new WebSocket(location.origin.replace('http', 'ws') + '/socket' + location.pathname);
+	    ws = new WebSocket(location.origin.replace('http', 'ws') + '/socket' + location.pathname);
 		// ws = new WebSocket('wss://loult.family/socket/toast');
 		ws.binaryType = 'arraybuffer';
 

--- a/static/style.css
+++ b/static/style.css
@@ -1,4 +1,4 @@
-﻿@font-face {
+@font-face {
 	font-family: "PokemonGB";
 	src: url("/fonts/PokemonGB.eot");
 	src: url("/fonts/PokemonGB.eot?#iefix") format("embedded-opentype"), 
@@ -831,9 +831,8 @@ select {
 }
 
 .night #close, .night #chat > div > div:first-child, .night ul > li > div > div:first-child > div {
-	background-color: #2B2B2B;
+	background-color: #505151;
 }
-/*.night footer > div > i:hover { background-color: #111; }*/
 
 .night footer > div > .icon:hover { background-color: #111; }
 
@@ -937,7 +936,11 @@ select {
 	overflow: hidden; 
 }
 .icon img { 
-	margin: 10px; 
+	margin: 8px; 
+	transition: 0.3s;
+}
+.icon img:hover {
+	margin: 6px;
 }				
 .tooltiptext {
   font-family: "PokemonGB";
@@ -950,7 +953,7 @@ select {
   height: 10px;					  
   /* Position du tooltip */
   position: absolute;
-  bottom: 60px;
+  bottom: 70px;
   right: 0;
   text-align: left;
   z-index: 1;
@@ -968,4 +971,124 @@ select {
 	0% { -webkit-filter: hue-rotate(0deg); filter: hue-rotate(0deg); }
 	50% { -webkit-filter: hue-rotate(180deg); filter: hue-rotate(180deg); }
 	100% { -webkit-filter: hue-rotate(360deg); filter: hue-rotate(360deg); }
+}
+
+/***** bibw *****/ 
+
+body.bibw {
+  background : -moz-linear-gradient(50% 1.37% -90deg,rgba(80, 81, 81, 1) 0%,rgba(72, 73, 73, 1) 1.44%,rgba(51, 52, 52, 1) 6.36%,rgba(38, 38, 38, 1) 11.11%,rgba(34, 34, 34, 1) 15.48%,rgba(34, 34, 34, 1) 100%);
+  background : -webkit-linear-gradient(-90deg, rgba(80, 81, 81, 1) 0%, rgba(72, 73, 73, 1) 1.44%, rgba(51, 52, 52, 1) 6.36%, rgba(38, 38, 38, 1) 11.11%, rgba(34, 34, 34, 1) 15.48%, rgba(34, 34, 34, 1) 100%);
+  background : -webkit-gradient(linear,50% 1.37% ,50% 100% ,color-stop(0,rgba(80, 81, 81, 1) ),color-stop(0.0144,rgba(72, 73, 73, 1) ),color-stop(0.0636,rgba(51, 52, 52, 1) ),color-stop(0.1111,rgba(38, 38, 38, 1) ),color-stop(0.1548,rgba(34, 34, 34, 1) ),color-stop(1,rgba(34, 34, 34, 1) ));
+  background : -o-linear-gradient(-90deg, rgba(80, 81, 81, 1) 0%, rgba(72, 73, 73, 1) 1.44%, rgba(51, 52, 52, 1) 6.36%, rgba(38, 38, 38, 1) 11.11%, rgba(34, 34, 34, 1) 15.48%, rgba(34, 34, 34, 1) 100%);
+  background : -ms-linear-gradient(-90deg, rgba(80, 81, 81, 1) 0%, rgba(72, 73, 73, 1) 1.44%, rgba(51, 52, 52, 1) 6.36%, rgba(38, 38, 38, 1) 11.11%, rgba(34, 34, 34, 1) 15.48%, rgba(34, 34, 34, 1) 100%);
+  -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr='#505151', endColorstr='#222222' ,GradientType=0)";
+  background : linear-gradient(180deg, rgba(80, 81, 81, 1) 0%, rgba(72, 73, 73, 1) 1.44%, rgba(51, 52, 52, 1) 6.36%, rgba(38, 38, 38, 1) 11.11%, rgba(34, 34, 34, 1) 15.48%, rgba(34, 34, 34, 1) 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#505151',endColorstr='#222222' , GradientType=0);
+}
+
+.bibw #chat > div > :nth-child(2) > div:not(:first-child), .bibw ul > li > div > div {
+	color: #EEE;
+}
+
+.bibw, .bibw ul, .bibw #window, .bibw #input, .bibw select {
+	background: #222;
+	color: #EEE;
+
+}
+.bibw ul > li:first-of-type {
+	margin-top: 30px;
+}
+
+.bibw ul > li > i, .bibw select, .bibw footer > div > i {
+	color: #DDD;
+}
+
+.bibw #close, .bibw #chat > div > div:first-child, .bibw ul > li > div > div:first-child > div {
+	background-color: #494949;
+}
+
+.bibw main, .bibw #window > div:first-child, .bibw footer > div, .bibw footer > div > i, .bibw ul, .bibw #close, .bibw #window, .bibw ul > li > div > div:last-child {
+	border: none!important;
+	background: none;
+}
+
+.bibw header {
+    background: none!important;
+    position: absolute;
+    width: 100%;
+}
+
+.bibw footer {
+	background: none !important;
+	margin-bottom: 15px;
+    margin-left: 10px;
+    margin-right: 0;
+}
+
+.bibw ul > li > div {
+	background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0) 35px, #222 35px, #222 100%);
+}
+
+.bibw #underlay {
+  -webkit-filter: invert(50%) brightness(200%);
+  filter: invert(50%) brightness(200%);
+}
+
+.bibw ::-webkit-scrollbar-track {
+	background-color: #222;
+}
+
+.bibw ::-webkit-scrollbar, .bibw ::-webkit-scrollbar-thumb {
+	background-color: #333;
+}
+
+.bibw ::-webkit-scrollbar-track, .bibw ::-webkit-scrollbar, .bibw ::-webkit-scrollbar-thumb {
+	border-color: #222;
+}
+
+.bibw > footer#foot > input { 
+	background: #0C0C0C; 
+	border-radius: 50px; 
+	font-family: 'Pokemon GB';    
+	font-size: 22px!important;
+	line-height: 50px;
+	margin-right: 10px;
+    margin-left: 10px; 
+    padding: 5px 25px;
+}
+
+.bibw #chat > div > div:last-child {
+	color: #505151!important;
+    font-size: 10px;
+    padding-right: 15px;
+}	
+.bibw footer > div {
+	margin-right: 20px;
+}
+
+.bibw #chat > div > div:first-child > img:nth-child(1)/*, .bibw #chat > div > div:first-child > img:nth-child(2), .bibw #chat > div > div:first-child > img:nth-child(3) */{
+	display: block;
+}
+
+.bibw #chat > div > :first-child {
+    width: 40px;
+    max-width: 40px;
+    max-height: 40px;
+    margin-left: 25px;
+}
+
+.bibw footer > div > .icon {
+	border-radius: 50px;
+}
+
+.bibw footer > div > .icon:hover {
+	background-color: #505151;
+}
+.bibw #overlay > #cover {
+	background: rgba(0, 0, 0, .66);
+}
+
+.pokeball {
+	width: 17px;
+	height: 17px;
 }


### PR DESCRIPTION
- Ajout de la class bibw dans le menu thèmes
- tout le css du thème est à la fin de style.css
- ajout fonction js quand on mouseover le coffre
- ajout pokeball qui remplace info_outline pour les évènements du chat (test)

Note d'usage : inutile de changer la couleur, le thème bibw est tout en un pour l'instant. J'attends le retour des utilisateurs pour debug et éventuellement changer des trucs 