### PR TITLE
Ban IP avec durée optionnelle via /mod

### DIFF
--- a/poke.py
+++ b/poke.py
@@ -6,7 +6,7 @@ from itertools import chain
 
 from tools.ban import Ban, BanFail
 from tools.client import ClientRouter, LoultServerProtocol
-from tools.handlers import (MessageHandler, BinaryHandler, TrashHandler, BanHandler, ShadowbanHandler,
+from tools.handlers import (MessageHandler, BinaryHandler, TrashHandler, IpBanHandler,  BanHandler, ShadowbanHandler,
                             NoRenderMsgHandler, AttackHandler, PrivateMessageHandler, MoveHandler,
                             InventoryListingHandler, ObjectGiveHandler, ObjectUseHandler, ObjectTrashHandler,
                             ListChannelInventoryHandler, ObjectTakeHandler, WeaponsGrantHandler)
@@ -79,6 +79,7 @@ if __name__ == "__main__":
     #moderation handlers
     router.add_route(field="mod", value="trash", handler_class=TrashHandler)
     router.add_route(field="mod", value="shadowban", handler_class=ShadowbanHandler)
+    router.add_route(field="mod", value="ipban", handler_class=IpBanHandler)
     for ban_type in Ban.ban_types:
         router.add_route(field="mod", value=ban_type, handler_class=BanHandler)
     router.add_route(field="mod", value="grant", handler_class=WeaponsGrantHandler)

--- a/static/script.js
+++ b/static/script.js
@@ -662,8 +662,20 @@ document.addEventListener('DOMContentLoaded', function() {
 			ws.send(JSON.stringify({ type : 'take', object_id: parseInt(splitted[1])}));
 		    }
 		    else if(trimed.match(/^\/mod\s/i)) {
-			var splitted = trimed.split(' ');
-			ws.send(JSON.stringify({ mod : splitted[1], params : splitted.slice(2)}));
+			parsed_cmd = trimed.match(/^\/mod (\w+) ?(\w+)? ?(\d+)? ?(\d+)?$/i);
+			var action = parsed_cmd[1];
+			var params = [];
+			var target = params[0];
+			var order = params[1] ? typeof params[1] !== 'undefined' : 0;
+			var duration = params[2] ? typeof params[2] !== 'undefined' : 1200;
+			for(var i = 2; i <= 4; i++) params.push(parsed_cmd[i]);
+			if (action === 'grant') {
+			    ws.send(JSON.stringify({ mod : action, params : params}));
+			}
+			else if(action === 'banniw') {
+			    ws.send(JSON.stringify({ 'mod' : 'ipban', 'action' : 'apply', 'target' : target,
+							 'order' : order, 'duration' : duration}));
+			}
 		    }
 		    else if(trimed.match(/^\/trash\s/i)) {
 			var splitted = trimed.split(' ');

--- a/static/script.js
+++ b/static/script.js
@@ -662,13 +662,18 @@ document.addEventListener('DOMContentLoaded', function() {
 			ws.send(JSON.stringify({ type : 'take', object_id: parseInt(splitted[1])}));
 		    }
 		    else if(trimed.match(/^\/mod\s/i)) {
-			parsed_cmd = trimed.match(/^\/mod (\w+) ?(\w+)? ?(\d+)? ?(\d+)?$/i);
+			reg = /^\/mod (\w+) ?(\w+)? ?(\d+)? ?(?:d=(\d+))?$/i;
+			var parsed_cmd;
+			if (trimed.match(reg))
+			    parsed_cmd = trimed.match(reg);
+			else
+			    return;
 			var action = parsed_cmd[1];
 			var params = [];
-			var target = params[0];
-			var order = params[1] ? typeof params[1] !== 'undefined' : 0;
-			var duration = params[2] ? typeof params[2] !== 'undefined' : 1200;
 			for(var i = 2; i <= 4; i++) params.push(parsed_cmd[i]);
+			var target = params[0];
+			var order = typeof params[1] !== 'undefined' ? params[1] : 0;
+			var duration = typeof params[2] !== 'undefined' ? params[2] : 1200;
 			if (action === 'grant') {
 			    ws.send(JSON.stringify({ mod : action, params : params}));
 			}

--- a/static/script.js
+++ b/static/script.js
@@ -678,6 +678,8 @@ document.addEventListener('DOMContentLoaded', function() {
 			    ws.send(JSON.stringify({ mod : action, params : params}));
 			}
 			else if(action === 'banniw') {
+			    if(typeof target === 'undefined')
+				return;
 			    ws.send(JSON.stringify({ 'mod' : 'ipban', 'action' : 'apply', 'target' : target,
 							 'order' : order, 'duration' : duration}));
 			}

--- a/tools/handlers.py
+++ b/tools/handlers.py
@@ -320,7 +320,7 @@ class TrashHandler(MsgBaseHandler):
 
 class IpBanHandler(MsgBaseHandler):
 
-    # cmd : /mod banniw <target_name> [<target_order>] [<duration_in_seconds>]
+    # cmd : /mod banniw <target_name> [<target_order>] [d=<duration_in_seconds>]
 
     @cookie_check(MOD_COOKIES)
     async def handle(self, msg_data: Dict):
@@ -329,7 +329,6 @@ class IpBanHandler(MsgBaseHandler):
             order = msg_data.get('order')
         else:
             order = 0
-        print(msg_data.get('duration'))
         if msg_data.get('duration') and int(msg_data.get('duration')) > 0:
             duration = int(msg_data.get('duration'))
         else:
@@ -347,7 +346,6 @@ class IpBanHandler(MsgBaseHandler):
         if msg_data["action"] == "apply":
             for client in banned_user.clients:
                 if client.user is not None and client.user.user_id == user_id:
-                    print(duration)
                     self.loult_state.ban_ip(client.ip, duration)
                     client.sendClose(code=4006, reason="Reconnect later.")
                     self.server.send_json(type="ipban", userid=user_id, state="apply_ok")

--- a/tools/state.py
+++ b/tools/state.py
@@ -160,9 +160,11 @@ class LoultServerState:
         loop = get_event_loop()
         loop.call_later(BAN_TIME * 60, self.banned_cookies.remove, cookie)
 
-    def ban_ip(self, ip: str):
+    def ban_ip(self, ip: str, ban_duration = BAN_TIME):
         if ip in self.banned_ips:
             return
         self.banned_ips.add(ip)
         loop = get_event_loop()
         loop.call_later(BAN_TIME * 60 * 2, self.banned_ips.remove, ip)
+
+


### PR DESCRIPTION
Bonjour,

Voici une option supplémentaire de modération qui s'utilise via le client :
` /mod banniw <target_name> [<target_order>] [d=<duration_in_seconds>]`

La durée est optionnelle et spécifiée en secondes.

Un shadowban avec les adresses *in-memory* peut être réalisé sur le même principe, idéalement sans trop dupliquer la logique de celui qui existe déjà en backend.

Bon travail